### PR TITLE
feat: include full volunteer profiles in venue detail response

### DIFF
--- a/Application/Common/Mappings/VenueMappingProfile.cs
+++ b/Application/Common/Mappings/VenueMappingProfile.cs
@@ -43,23 +43,7 @@ namespace Application.Common.Mappings
                             ? $"{src.Coordinator.FirstName} {src.Coordinator.LastName}"
                             : "Unknown Coordinator"))
                 .ForMember(dest => dest.TimeSlots,
-                    opt => opt.MapFrom(src => src.TimeSlots))
-                .ForMember(dest => dest.Volunteers,
-                    opt => opt.MapFrom(src => src.VolunteerApplications
-                        .Where(va => va.Status == VolunteerApplicationStatus.Approved)
-                        .Select(va => new VolunteerSummaryDto
-                        {
-                            VolunteerId = va.VolunteerId,
-                            VolunteerName = $"{va.Volunteer.FirstName} {va.Volunteer.LastName}",
-                            Subjects = va.Volunteer.VolunteerSubjects
-                                .Select(vs => new SubjectDto
-                                {
-                                    Id = vs.Subject.Id,
-                                    Name = vs.Subject.Name,
-                                    Icon = vs.Subject.Icon
-                                })
-                                .ToList()
-                        })));
+                    opt => opt.MapFrom(src => src.TimeSlots));
         }
     }
 }

--- a/Application/Venues/Dtos/VenueDtos.cs
+++ b/Application/Venues/Dtos/VenueDtos.cs
@@ -1,5 +1,6 @@
 using Application.Subjects.Dtos;
 using Application.TimeSlots.Dtos;
+using Application.Volunteers.Dtos;
 using Domain.Models.Enums;
 
 namespace Application.Venues.Dtos
@@ -63,15 +64,8 @@ namespace Application.Venues.Dtos
         /// <summary>
         /// Approved volunteers working at this venue
         /// </summary>
-        public List<VolunteerSummaryDto> Volunteers { get; set; } = new();
-    }
+        public List<VolunteerProfileDto> Volunteers { get; set; } = new();
 
-    // Remove the placeholder below when Voluteer features are implemented
-    public class VolunteerSummaryDto
-    {
-        public Guid VolunteerId { get; set; }
-        public required string VolunteerName { get; set; }
-        public List<SubjectDto> Subjects { get; set; } = new();
     }
 
     /// <summary>

--- a/Application/Venues/Queries/GetVenueById/GetVenueByIdQueryHandler.cs
+++ b/Application/Venues/Queries/GetVenueById/GetVenueByIdQueryHandler.cs
@@ -1,5 +1,6 @@
 using Application.Common.Interfaces;
 using Application.Venues.Dtos;
+using Application.Venues.Queries.GetVenueVolunteers;
 using AutoMapper;
 using Domain.Models.Common;
 using MediatR;
@@ -13,21 +14,34 @@ namespace Application.Venues.Queries.GetVenueById
     {
         private readonly IVenueRepository _venueRepository;
         private readonly IMapper _mapper;
-        public GetVenueByIdQueryHandler(IVenueRepository venueRepository, IMapper mapper)
+        private readonly IMediator _mediator;
+
+        public GetVenueByIdQueryHandler(IVenueRepository venueRepository, IMapper mapper, IMediator mediator)
         {
             _venueRepository = venueRepository;
             _mapper = mapper;
+            _mediator = mediator;
         }
+
         public async Task<OperationResult<VenueDetailDto>> Handle(GetVenueByIdQuery request, CancellationToken cancellationToken)
         {
             var venue = await _venueRepository.GetByIdWithDetailsAsync(request.VenueId);
 
             if (venue == null)
-            {
                 return OperationResult<VenueDetailDto>.Failure("Venue not found.");
-            }
 
             var dto = _mapper.Map<VenueDetailDto>(venue);
+
+            var volunteersResult = await _mediator.Send(
+                new GetVenueVolunteersQuery(request.VenueId),
+                cancellationToken);
+
+            if (!volunteersResult.IsSuccess)
+                return OperationResult<VenueDetailDto>.Failure(
+                    volunteersResult.Errors.ToArray());
+
+            dto.Volunteers = volunteersResult.Data ?? new();
+
             return OperationResult<VenueDetailDto>.Success(dto);
         }
     }

--- a/Application/Volunteers/Dtos/VolunteerProfileDto.cs
+++ b/Application/Volunteers/Dtos/VolunteerProfileDto.cs
@@ -6,6 +6,7 @@ namespace Application.Volunteers.Dtos
     public class VolunteerProfileDto
     {
         public Guid VolunteerId { get; set; }
+        public string VolunteerName { get; set; } = string.Empty;
         public string Bio { get; set; } = string.Empty;
         public string Experience { get; set; } = string.Empty;
         public int? MaxHoursPerWeek { get; set; }

--- a/Application/Volunteers/Mapping/VolunteerMappingProfile.cs
+++ b/Application/Volunteers/Mapping/VolunteerMappingProfile.cs
@@ -11,7 +11,9 @@ namespace Application.Volunteers.Mapping
         public VolunteerMappingProfile()
         {
             // Volunteer profile (subjects handled separately)
-            CreateMap<VolunteerProfile, VolunteerProfileDto>();
+            CreateMap<VolunteerProfile, VolunteerProfileDto>()
+                .ForMember(d => d.VolunteerName,
+                opt => opt.MapFrom(src => $"{src.Volunteer.FirstName} {src.Volunteer.LastName}"));
 
             // Subject catalog mapping
             CreateMap<Domain.Models.Entities.Subjects.Subject, SubjectDto>();

--- a/Infrastructure/Repositories/VolunteerProfileRepository.cs
+++ b/Infrastructure/Repositories/VolunteerProfileRepository.cs
@@ -15,7 +15,9 @@ namespace Infrastructure.Repositories
         }
 
         public Task<VolunteerProfile?> GetByVolunteerIdAsync(Guid volunteerId)
-            => _db.VolunteerProfiles.FirstOrDefaultAsync(x => x.VolunteerId == volunteerId);
+            => _db.VolunteerProfiles
+                .Include(x => x.Volunteer)
+                .FirstOrDefaultAsync(x => x.VolunteerId == volunteerId);
 
         public async Task UpsertAsync(VolunteerProfile profile)
         {


### PR DESCRIPTION
- Extend GET /api/venues/{id} to return volunteer bio and experience
- Include volunteer subject confidence levels
- Populate volunteerName via VolunteerProfile → User relation
- Compose venue detail using GetVenueVolunteers query (remove inline mapping)
- Note: volunteer subjects are returned as { subject, confidenceLevel } instead of flat { name, confidenceLevel }

